### PR TITLE
Fix do pack completion

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@
 
 [Commits](https://github.com/HKey/dired-atool/compare/1.1.0...master)
 
+- Fix file name completion of `dired-atool-do-pack`.
+
 ## 1.1.0 (2016/02/07)
 
 [Commits](https://github.com/HKey/dired-atool/compare/1.0.0...1.1.0)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,7 @@
 
 [Commits](https://github.com/HKey/dired-atool/compare/1.1.0...master)
 
-- Fix file name completion of `dired-atool-do-pack`.
+- Fix file name completion of `dired-atool-do-pack`. ([#3](https://github.com/HKey/dired-atool/pull/3))
 
 ## 1.1.0 (2016/02/07)
 

--- a/dired-atool.el
+++ b/dired-atool.el
@@ -168,7 +168,7 @@ ARG is used for `dired-get-marked-files'."
          (archive (expand-file-name ; to expand "~" to a real path name
                    (dired-mark-pop-up
                     nil nil files
-                    #'read-directory-name
+                    #'read-file-name
                     (format "Pack %s to: "
                             (dired-atool--file-names-for-prompt files))
                     (dired-dwim-target-directory))))


### PR DESCRIPTION
`dired-atool-do-pack` needs a file name, not a directory name.
So, use `read-file-name` instead of `read-directory-name`.

Related to #2.